### PR TITLE
Port bionic beaver

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+
+MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+
+# Disable interactive functions
+ENV DEBIAN_FRONTEND noninteractive
+
+# Update Ubuntu
+RUN apt update && apt upgrade -y --autoremove && \
+    apt clean && rm -rf /var/lib/apt/lists/*
+
+# Install some utilities
+RUN apt update && \
+    apt install -y software-properties-common \
+        language-pack-en-base nano wget && \
+    apt clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-16.04/Dockerfile
+18.04/Dockerfile

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ docker run -d ghifari160/ubuntu
 
 ## Tags ##
 | Tags                      | Ubuntu Version | Size              |
-|---------------------------|----------------|-------------------|
-| `latest` `16.04` `xenial` | 16.04          |[![](https://images.microbadger.com/badges/image/ghifari160/ubuntu.svg)](https://microbadger.com/images/ghifari160/ubuntu "Get your own image badge on microbadger.com")|
+|---------------------------|----------------|:-----------------:|
+| `16.04` `xenial` | 16.04          |[![](https://images.microbadger.com/badges/image/ghifari160/ubuntu:16.04.svg)](https://microbadger.com/images/ghifari160/ubuntu:16.04 "Get your own image badge on microbadger.com")|
 | `17.04` `zesty`           | 17.04          | **NOT SUPPORTED** |
 | `17.10` `artful`          | 17.10          |[![](https://images.microbadger.com/badges/image/ghifari160/ubuntu:17.10.svg)](https://microbadger.com/images/ghifari160/ubuntu:17.10 "Get your own image badge on microbadger.com")|
+| `latest` `18/04` `bionic` | 18.04          |[![](https://images.microbadger.com/badges/image/ghifari160/ubuntu.svg)](https://microbadger.com/images/ghifari160/ubuntu "Get your own image badge on microbadger.com")|
 
 [g16-ub-issue]: https://github.com/ghifari160/docker-ubuntu/issues


### PR DESCRIPTION
This PR ports Ubuntu 18.04 LTS (latest) as a Docker image. The `latest` tag will point to `bionic` instead of `xenial`.